### PR TITLE
Fix azure-pipelines.yml to use `npm install:ci` vs `npm install`

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,7 @@ steps:
 
 - task: Npm@1
   inputs:
-    command: ci
+    command: install:ci
   displayName: 'npm Install'
 
 - task: Npm@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,7 +34,7 @@ steps:
 
 - task: PublishTestResults@2
   condition: succeededOrFailed()
-  inputs: 
+  inputs:
     testRunner: JUnit
     testResultsFiles: '$(System.DefaultWorkingDirectory)/coverage/junit.xml'
   displayName: 'Publish Test Results'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,7 +34,8 @@ steps:
 
 - task: PublishTestResults@2
   condition: succeededOrFailed()
-  inputs: testRunner: JUnit
+  inputs: 
+  testRunner: JUnit
     testResultsFiles: '$(System.DefaultWorkingDirectory)/coverage/junit.xml'
   displayName: 'Publish Test Results'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,7 @@ steps:
 
 - task: Npm@1
   inputs:
-    command: install
+    command: ci
   displayName: 'npm Install'
 
 - task: Npm@1
@@ -34,8 +34,7 @@ steps:
 
 - task: PublishTestResults@2
   condition: succeededOrFailed()
-  inputs:
-    testRunner: JUnit
+  inputs: testRunner: JUnit
     testResultsFiles: '$(System.DefaultWorkingDirectory)/coverage/junit.xml'
   displayName: 'Publish Test Results'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,7 +35,7 @@ steps:
 - task: PublishTestResults@2
   condition: succeededOrFailed()
   inputs: 
-  testRunner: JUnit
+    testRunner: JUnit
     testResultsFiles: '$(System.DefaultWorkingDirectory)/coverage/junit.xml'
   displayName: 'Publish Test Results'
 


### PR DESCRIPTION
Moved azure-pipelines.yml to use `npm install:ci` vs. `npm install`

In personal testing, it seemed to shave off a second and a half. Does this sound reasonable?

Ref #13 